### PR TITLE
spotify-adblock: Include config.toml and patch /src/lib.rs

### DIFF
--- a/pkgs/spotify-adblock/default.nix
+++ b/pkgs/spotify-adblock/default.nix
@@ -15,6 +15,24 @@
       hash = "sha256-5tZ+Y7dhzb6wmyQ+5FIJDHH0KqkXbiB259Yo7ATGjSU=";
     };
     cargoSha256 = "sha256-VwYMDEbFhGmpWCrdh/Aa49vvalh42C6E3/t067mxmoI=";
+
+    patchPhase = ''
+      substituteInPlace src/lib.rs \
+        --replace 'config.toml' $out/etc/spotify-adblock/config.toml
+    '';
+
+    buildPhase = ''
+      make
+     '';
+
+    installPhase = ''
+      mkdir -p $out/etc/spotify-adblock
+      install -D --mode=644 config.toml $out/etc/spotify-adblock
+      mkdir -p $out/lib
+      install -D --mode=644 --strip target/release/libspotifyadblock.so $out/lib
+      
+    '';
+
   };
   spotifywm = stdenv.mkDerivation {
     name = "spotifywm";


### PR DESCRIPTION
Hello, thank you for putting spotify-adblock together for us Nix users. Saved me from having to come up with this solution myself.

When I installed your package, I noticed I was still getting ads on a fairly regular basis. After digging around for a while and browsing over [the original source code](https://github.com/abba23/spotify-adblock), I noticed that the package searches for a `config.toml` file in some hardcoded locations. Of course, none of these locations are accessible by the nix sandbox. This led to it being unable to access the allowlist and denylist that `spotify-adblock` needs to block ads.

I have included the necessary install changes to include config.toml inside the nix store as well as a `substituteInPlace` patch to replace the hardcoded config.toml path to the one that lives inside of `/nix/store`. After making this change I stopped receiving ads.

Hope this helps. Thanks again