### PR TITLE
Hide placeholder for Spotify advert banner

### DIFF
--- a/pkgs/spotify-adblock/default.nix
+++ b/pkgs/spotify-adblock/default.nix
@@ -4,6 +4,8 @@
   rustPlatform,
   fetchFromGitHub,
   xorg,
+  zip,
+  unzip,
 }: let
   spotify-adblock = rustPlatform.buildRustPackage {
     pname = "spotify-adblock";
@@ -48,6 +50,7 @@
 in
   spotify.overrideAttrs (
     old: {
+      buildInputs = (old.buildInputs or [ ]) ++ [ zip unzip ];
       postInstall =
         (old.postInstall or "")
         + ''
@@ -55,6 +58,11 @@ in
           sed -i "s:^Name=Spotify.*:Name=Spotify-adblock:" "$out/share/spotify/spotify.desktop"
           wrapProgram $out/bin/spotify \
             --set LD_PRELOAD "${spotify-adblock}/lib/libspotifyadblock.so"
+
+          # Hide placeholder for advert banner
+          ${unzip}/bin/unzip -p $out/share/spotify/Apps/xpui.spa xpui.js | sed 's/adsEnabled:\!0/adsEnabled:false/' > $out/share/spotify/Apps/xpui.js
+          ${zip}/bin/zip --junk-paths --update $out/share/spotify/Apps/xpui.spa $out/share/spotify/Apps/xpui.js
+          rm $out/share/spotify/Apps/xpui.js
         '';
     }
   )


### PR DESCRIPTION
Hi, thanks for making and maintaining spotify-adblock.

I noticed Spotify's desktop app would still show an empty placeholder for advert banner at the bottom. I've made a few changes by referring to how this AUR package hides this placeholder:
https://aur.archlinux.org/packages/spotify-remove-ad-banner

I don't see the empty placeholder after the changes in this PR. I'm also new to everything nix, apologies if something doesn't seem right.