### PR TITLE
Change `cargoHash` to `cargoSha256` so it stops the warning

### DIFF
--- a/pkgs/spotify-adblock/default.nix
+++ b/pkgs/spotify-adblock/default.nix
@@ -16,7 +16,7 @@
       rev = "5a3281dee9f889afdeea7263558e7a715dcf5aab";
       hash = "sha256-UzpHAHpQx2MlmBNKm2turjeVmgp5zXKWm3nZbEo0mYE=";
     };
-    cargoSha256 = "sha256-wPV+ZY34OMbBrjmhvwjljbwmcUiPdWNHFU3ac7aVbIQ=";
+    cargoHash = "sha256-wPV+ZY34OMbBrjmhvwjljbwmcUiPdWNHFU3ac7aVbIQ=";
 
     patchPhase = ''
       substituteInPlace src/lib.rs \


### PR DESCRIPTION
Whenever I build my system now, it gives a warning:

~~~
evaluation warning: cargoSha256 is deprecated. Please use cargoHash with SRI hash instead
~~~

This commit fixes that.