### PR TITLE
Fix hiding of Spotify advert banner placeholder

### DIFF
--- a/pkgs/spotify-adblock/default.nix
+++ b/pkgs/spotify-adblock/default.nix
@@ -59,9 +59,9 @@ in
             --set LD_PRELOAD "${spotify-adblock}/lib/libspotifyadblock.so"
 
           # Hide placeholder for advert banner
-          ${unzip}/bin/unzip -p $out/share/spotify/Apps/xpui.spa xpui.js | sed 's/adsEnabled:\!0/adsEnabled:false/' > $out/share/spotify/Apps/xpui.js
-          ${zip}/bin/zip --junk-paths --update $out/share/spotify/Apps/xpui.spa $out/share/spotify/Apps/xpui.js
-          rm $out/share/spotify/Apps/xpui.js
+          ${unzip}/bin/unzip -p $out/share/spotify/Apps/xpui.spa xpui-snapshot.js | sed 's/adsEnabled:\!0/adsEnabled:false/' > $out/share/spotify/Apps/xpui-snapshot.js
+          ${zip}/bin/zip --junk-paths --update $out/share/spotify/Apps/xpui.spa $out/share/spotify/Apps/xpui-snapshot.js
+          rm $out/share/spotify/Apps/xpui-snapshot.js
         '';
     }
   )


### PR DESCRIPTION
Looks like Spotify has renamed `xpui.js` to `xpui-snapshot.js` in recent versions.

Fixes #36.