### PR TITLE
refactor: track tagged version to avoid unpredicated hash mismatches

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## packages in repository:
 
 1. spotify-adblock
-using https://github.com/abba23/spotify-adblock and https://github.com/dasJ/spotifywm/
+using https://github.com/abba23/spotify-adblock
 Listen to spotify without banner ads and interupting audio ads
 2. ciscoPacketTracer8
 This version of packettracer8 automatically installs the required .deb from GitLFS, instead of the slow public link.

--- a/pkgs/spotify-adblock/default.nix
+++ b/pkgs/spotify-adblock/default.nix
@@ -1,21 +1,21 @@
 {
   spotify,
-  stdenv,
   rustPlatform,
   fetchFromGitHub,
-  xorg,
   zip,
   unzip,
-}: let
+}:
+let
+  version = "1.1.1";
   spotify-adblock = rustPlatform.buildRustPackage {
+    inherit version;
     pname = "spotify-adblock";
-    version = "lastcommit at 2026-06-29";
     src = fetchFromGitHub {
       owner = "abba23";
       repo = "spotify-adblock";
-      rev = "refs/heads/main";
+      rev = "refs/tags/v${version}";
       fetchSubmodules = false;
-      hash = "sha256-3X7vScKmnb65wJ4xWAT2AeyAMPTGzKZCFA549zm9gLc=";
+      hash = "sha256-R1xM/a+EzFd3I94EVCphbW+M114x6CtIeCOi9Fd9tpc=";
     };
     cargoHash = "sha256-gxGetdqaoJa/ZF1VnW6UXJyJfLBGZxZnyKpT/Qk/8Og=";
 
@@ -36,33 +36,21 @@
       install -D --mode=644 --strip target/release/libspotifyadblock.so $out/lib
     '';
   };
-spotifywm = stdenv.mkDerivation {
-    name = "spotifywm";
-    src = fetchFromGitHub {
-      owner = "dasj";
-      repo = "spotifywm";
-      rev = "8624f539549973c124ed18753881045968881745";
-      hash = "sha256-AsXqcoqUXUFxTG+G+31lm45gjP6qGohEnUSUtKypew0=";
-    };
-    buildInputs = [xorg.libX11];
-    installPhase = "mv spotifywm.so $out";
-  };
 in
-  spotify.overrideAttrs (
-    old: {
-      buildInputs = (old.buildInputs or [ ]) ++ [ zip unzip ];
-      postInstall =
-        (old.postInstall or "")
-        + ''
-          ln -s ${spotify-adblock}/lib/libspotifyadblock.so $libdir
-          sed -i "s:^Name=Spotify.*:Name=Spotify-adblock:" "$out/share/spotify/spotify.desktop"
-          wrapProgram $out/bin/spotify \
-            --set LD_PRELOAD "${spotify-adblock}/lib/libspotifyadblock.so"
+spotify.overrideAttrs (old: {
+  buildInputs = (old.buildInputs or [ ]) ++ [
+    zip
+    unzip
+  ];
+  postInstall = (old.postInstall or "") + ''
+    ln -s ${spotify-adblock}/lib/libspotifyadblock.so $libdir
+    sed -i "s:^Name=Spotify.*:Name=Spotify-adblock:" "$out/share/spotify/spotify.desktop"
+    wrapProgram $out/bin/spotify \
+      --set LD_PRELOAD "${spotify-adblock}/lib/libspotifyadblock.so"
 
-          # Hide placeholder for advert banner
-          ${unzip}/bin/unzip -p $out/share/spotify/Apps/xpui.spa xpui-snapshot.js | sed 's/adsEnabled:\!0/adsEnabled:false/' > $out/share/spotify/Apps/xpui-snapshot.js
-          ${zip}/bin/zip --junk-paths --update $out/share/spotify/Apps/xpui.spa $out/share/spotify/Apps/xpui-snapshot.js
-          rm $out/share/spotify/Apps/xpui-snapshot.js
-        '';
-    }
-  )
+    # Hide placeholder for advert banner
+    ${unzip}/bin/unzip -p $out/share/spotify/Apps/xpui.spa xpui-snapshot.js | sed 's/adsEnabled:\!0/adsEnabled:false/' > $out/share/spotify/Apps/xpui-snapshot.js
+    ${zip}/bin/zip --junk-paths --update $out/share/spotify/Apps/xpui.spa $out/share/spotify/Apps/xpui-snapshot.js
+    rm $out/share/spotify/Apps/xpui-snapshot.js
+  '';
+})


### PR DESCRIPTION
- remove `spotifywm` as deprecated
- bump version to `1.1.1`